### PR TITLE
Fix entity error

### DIFF
--- a/Entity/User.php
+++ b/Entity/User.php
@@ -107,9 +107,25 @@ class User extends ModelUser
      */
     protected $metas;
 
+    /**
+     * {@inheritdoc}
+     *
+     * @ORM\OneToMany(targetEntity="Kayue\WordpressBundle\Entity\Post", mappedBy="user")
+     */
+    protected $posts;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @ORM\OneToMany(targetEntity="Kayue\WordpressBundle\Entity\Comment", mappedBy="user")
+     */
+    protected $comments;
+
     public function __construct()
     {
         $this->metas = new ArrayCollection();
+        $this->posts = new ArrayCollection();
+        $this->comments = new ArrayCollection();
     }
 
     /**

--- a/Model/User.php
+++ b/Model/User.php
@@ -60,6 +60,16 @@ class User implements UserInterface, \Serializable
     protected $metas;
 
     /**
+     * @var Kayue\WordpressBundle\Entity\Post
+     */
+    private $posts;
+
+    /**
+     * @var Kayue\WordpressBundle\Entity\Comment
+     */
+    private $comments;
+
+    /**
      * Get ID
      *
      * @return int
@@ -269,6 +279,26 @@ class User implements UserInterface, \Serializable
     public function getMetas()
     {
         return $this->metas;
+    }
+
+    /**
+     * Get posts
+     *
+     * @return Doctrine\Common\Collections\Collection
+     */
+    public function getPosts()
+    {
+        return $this->posts;
+    }
+
+    /**
+     * Get comments
+     *
+     * @return Doctrine\Common\Collections\Collection
+     */
+    public function getComments()
+    {
+        return $this->comments;
     }
 
     /**


### PR DESCRIPTION
Fix the following errors:

`The association Kayue\WordpressBundle\Entity\Post#user refers to the inverse side field Kayue\WordpressBundle\Entity\User#posts which does not exist.`

and

`The association Kayue\WordpressBundle\Entity\Comment#user refers to the inverse side field Kayue\WordpressBundle\Entity\User#comments which does not exist.`
