### PR TITLE
Blog: when getting entity manager of first blog, return default entity manager

### DIFF
--- a/Model/Blog.php
+++ b/Model/Blog.php
@@ -2,8 +2,6 @@
 
 namespace Kayue\WordpressBundle\Model;
 
-use Kayue\WordpressBundle\Doctrine\WordpressEntityManager;
-
 class Blog implements BlogInterface
 {
     /**
@@ -35,7 +33,7 @@ class Blog implements BlogInterface
     /**
      * @param WordpressEntityManager $manager
      */
-    public function setEntityManager(WordpressEntityManager $manager)
+    public function setEntityManager($manager)
     {
         $this->entityManager = $manager;
     }


### PR DESCRIPTION
Returning a new manager cause issues with legacy code as well as security component, which grab users from default entity manager. 

In particular, having different entity managers can cause entities appear not persisted, giving errors.
