### PR TITLE
Blog: fix using multiple entity manager can cause wrong query

### DIFF
--- a/Model/BlogManager.php
+++ b/Model/BlogManager.php
@@ -5,7 +5,6 @@ namespace Kayue\WordpressBundle\Model;
 use \Redis;
 use \Memcache;
 use \Memcached;
-use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\DBAL\DBALException;
 use Kayue\WordpressBundle\Doctrine\WordpressEntityManager;
 use Kayue\WordpressBundle\Event\SwitchBlogEvent;
@@ -49,7 +48,7 @@ class BlogManager implements BlogManagerInterface
         $config = $this->getEntityManagerConfiguration();
 
         if (!isset($this->blogs[$id])) {
-            $em = WordpressEntityManager::create($this->container->get('database_connection'), $config);
+            $em = WordpressEntityManager::create($this->container->get('database_connection'), clone $config);
 
             $em->getMetadataFactory()->setCacheDriver($this->getCacheImpl('metadata_cache', $id));
             $em->getConfiguration()->setQueryCacheImpl($this->getCacheImpl('query_cache', $id));


### PR DESCRIPTION
Root cause: we were passing a Doctrine Config object _from the default entity manager_ into our new entity manager. As a result, when we set the cache implementation of our "presumed" new entity manager, we (wrongly) set the cache implementation of the default entity manager, because they shared the same config object.
