### PR TITLE
TablePrefixSubscriber now scans for a WPTable annotation

### DIFF
--- a/Annotation/WPTable.php
+++ b/Annotation/WPTable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Kayue\WordpressBundle\Annotation;
+
+use Doctrine\ORM\Mapping\Annotation;
+
+/**
+ * @Annotation
+ * @Target("CLASS")
+ */
+final class WPTable implements Annotation
+{
+}

--- a/Entity/Blog.php
+++ b/Entity/Blog.php
@@ -3,11 +3,13 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Blog as BaseBlog;
 
 /**
  * @ORM\Table(name="blogs")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class Blog extends BaseBlog
 {

--- a/Entity/Comment.php
+++ b/Entity/Comment.php
@@ -4,6 +4,7 @@ namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Comment as ModelComment;
 use Symfony\Component\Validator\Constraints as Constraints;
 
@@ -11,6 +12,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
  * @ORM\Table(name="comments")
  * @ORM\Entity
  * @ORM\HasLifecycleCallbacks
+ * @Kayue\WPTable
  */
 class Comment extends ModelComment
 {

--- a/Entity/CommentMeta.php
+++ b/Entity/CommentMeta.php
@@ -3,12 +3,14 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\CommentMeta as ModelCommentaMeta;
 use Symfony\Component\Validator\Constraints as Constraints;
 
 /**
  * @ORM\Table(name="commentmeta")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class CommentMeta extends ModelCommentaMeta
 {

--- a/Entity/Option.php
+++ b/Entity/Option.php
@@ -3,6 +3,7 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Option as ModelOption;
 use Symfony\Component\Validator\Constraints as Constraints;
 
@@ -11,6 +12,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
  *
  * @ORM\Table(name="options")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class Option extends ModelOption
 {

--- a/Entity/Post.php
+++ b/Entity/Post.php
@@ -4,6 +4,7 @@ namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Post as ModelPost;
 use Symfony\Component\Validator\Constraints as Constraints;
 
@@ -13,6 +14,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
  * @ORM\Table(name="posts")
  * @ORM\Entity
  * @ORM\HasLifecycleCallbacks
+ * @Kayue\WPTable
  */
 class Post extends ModelPost
 {

--- a/Entity/PostMeta.php
+++ b/Entity/PostMeta.php
@@ -3,6 +3,7 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\PostMeta as ModelPostMeta;
 use Symfony\Component\Validator\Constraints as Constraints;
 
@@ -11,6 +12,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
  *
  * @ORM\Table(name="postmeta")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class PostMeta extends ModelPostMeta
 {

--- a/Entity/Taxonomy.php
+++ b/Entity/Taxonomy.php
@@ -4,12 +4,14 @@ namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Taxonomy as ModelTaxonomy;
 use Symfony\Component\Validator\Constraints as Constraints;
 
 /**
  * @ORM\Table(name="term_taxonomy")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class Taxonomy extends ModelTaxonomy
 {

--- a/Entity/Term.php
+++ b/Entity/Term.php
@@ -3,12 +3,14 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\Term as ModelTerm;
 use Symfony\Component\Validator\Constraints as Constraints;
 
 /**
  * @ORM\Table(name="terms")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class Term extends ModelTerm
 {

--- a/Entity/User.php
+++ b/Entity/User.php
@@ -4,6 +4,7 @@ namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Symfony\Component\Validator\Constraints as Constraints;
 use Kayue\WordpressBundle\Model\User as ModelUser;
 use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
@@ -18,6 +19,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
  * @UniqueEntity({"fields": "nicename", "message": "Sorry, that nicename is already used."})
  * @UniqueEntity({"fields": "displayName", "message": "Sorry, that display name has already been taken."})
  * @ORM\HasLifecycleCallbacks
+ * @Kayue\WPTable
  */
 class User extends ModelUser
 {

--- a/Entity/UserMeta.php
+++ b/Entity/UserMeta.php
@@ -3,6 +3,7 @@
 namespace Kayue\WordpressBundle\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Kayue\WordpressBundle\Annotation as Kayue;
 use Kayue\WordpressBundle\Model\UserMeta as ModelUserMeta;
 use Symfony\Component\Validator\Constraints as Constraints;
 
@@ -11,6 +12,7 @@ use Symfony\Component\Validator\Constraints as Constraints;
  *
  * @ORM\Table(name="usermeta")
  * @ORM\Entity
+ * @Kayue\WPTable
  */
 class UserMeta extends ModelUserMeta
 {

--- a/Subscriber/TablePrefixSubscriber.php
+++ b/Subscriber/TablePrefixSubscriber.php
@@ -5,6 +5,8 @@ namespace Kayue\WordpressBundle\Subscriber;
 use Doctrine\Common\EventSubscriber;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Event\LoadClassMetadataEventArgs;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Kayue\WordpressBundle\Annotation\WPTable;
 
 class TablePrefixSubscriber implements EventSubscriber
 {
@@ -24,8 +26,21 @@ class TablePrefixSubscriber implements EventSubscriber
     {
         $classMetadata = $args->getClassMetadata();
 
-        // only apply to WordpressBundle's Entitiy
-        if ($classMetadata->namespace !== 'Kayue\WordpressBundle\Entity') {
+        // Get class annotations
+        $reader = new AnnotationReader();
+        $classAnnotations = $reader->getClassAnnotations($classMetadata->getReflectionClass());
+
+        // Search for WPTable annotation
+        $found = false;
+        foreach ($classAnnotations as $classAnnotation) {
+            if ($classAnnotation instanceof WPTable) {
+                $found = true;
+                break;
+            }
+        }
+
+        // Only apply to classes having WPTable annotation
+        if (!$found) {
             return;
         }
 


### PR DESCRIPTION
I'd like to be able to use your TablePrefixSubscriber for classes I'm developping in my project. Instead of scanning for namespace I'd rather use an annotation (or any mecanism you see fit).
