### PR TITLE
override the doctrine:fixtures:load command to not purge wordpress tables

### DIFF
--- a/FixturesCommand/LoadDataFixturesDoctrineCommand.php
+++ b/FixturesCommand/LoadDataFixturesDoctrineCommand.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Kayue\WordpressBundle\Command;
+namespace Kayue\WordpressBundle\FixturesCommand;
 
 use Doctrine\Bundle\FixturesBundle\Command\LoadDataFixturesDoctrineCommand as BaseLoadDataFixturesDoctrineCommand;
-use Kayue\WordpressBundle\Purger\ORMPurger;
 
 class LoadDataFixturesDoctrineCommand extends BaseLoadDataFixturesDoctrineCommand
 {

--- a/FixturesCommand/ORMPurger.php
+++ b/FixturesCommand/ORMPurger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kayue\WordpressBundle\Purger;
+namespace Kayue\WordpressBundle\FixturesCommand;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger as BaseORMPurger;
 
@@ -20,6 +20,7 @@ class ORMPurger extends BaseORMPurger
 
         $allMetadata = $this->getObjectManager()->getMetadataFactory()->getAllMetadata();
         foreach($allMetadata as $metadata) {
+
             if (strpos($metadata->table['name'], $this->tablePrefix) === 0) continue;
 
             $metadatas[] = $metadata;

--- a/KayueWordpressBundle.php
+++ b/KayueWordpressBundle.php
@@ -40,8 +40,12 @@ class KayueWordpressBundle extends Bundle
 
     public function registerCommands(Application $application)
     {
+        // override the default doctrine:fixtures:load command if it is registered
         if ($application->has('doctrine:fixtures:load')) {
-            parent::registerCommands($application);
+            $class = $this->getNamespace().'\FixturesCommand\LoadDataFixturesDoctrineCommand';
+            $application->add(new $class);
         }
+
+        parent::registerCommands($application);
     }
 }


### PR DESCRIPTION
Depends upon two upstream PRs getting accepted:
https://github.com/doctrine/data-fixtures/pull/153
https://github.com/doctrine/DoctrineFixturesBundle/pull/120
