### PR TITLE
Fix broken Attachment::getUrl

### DIFF
--- a/Model/Attachment.php
+++ b/Model/Attachment.php
@@ -42,6 +42,11 @@ class Attachment extends Post implements AttachmentInterface
 
     public function getUrl()
     {
+        if (!$this->url) {
+            $rawMeta = $this->metadata->getValue();
+            $this->url = $rawMeta['file'];
+        }
+
         return $this->url;
     }
 }


### PR DESCRIPTION
Closes https://github.com/kayue/KayueWordpressBundle/issues/41

If no url is set, set the url to the metadata file.
