### PR TITLE
Register custom DQL functions

### DIFF
--- a/Wordpress/ManagerRegistry.php
+++ b/Wordpress/ManagerRegistry.php
@@ -46,10 +46,11 @@ class ManagerRegistry
         }
 
         if (!isset($this->entityManagers[$blogId])) {
+            $defaultConfig = $this->defaultEntityManager->getConfiguration();
             $config = Setup::createAnnotationMetadataConfiguration([], 'prod' !== $this->environment, null, null, false);
             $config->addEntityNamespace('KayueWordpressBundle', 'Kayue\WordpressBundle\Entity');
             $config->setAutoGenerateProxyClasses(true);
-            $config->setProxyDir($this->defaultEntityManager->getConfiguration()->getProxyDir());
+            $config->setProxyDir($defaultConfig->getProxyDir());
 
             $em = WordpressEntityManager::create($this->connection, $config);
 
@@ -57,6 +58,10 @@ class ManagerRegistry
             $em->getMetadataFactory()->setCacheDriver($this->getCacheImpl('metadata_cache', $this->currentBlogId));
             $em->getConfiguration()->setQueryCacheImpl($this->getCacheImpl('query_cache', $this->currentBlogId));
             $em->getConfiguration()->setResultCacheImpl($this->getCacheImpl('result_cache', $this->currentBlogId));
+
+            if (null !== $fieldFunction = $defaultConfig->getCustomStringFunction('field')) {
+                $em->getConfiguration()->addCustomStringFunction('field', $fieldFunction);
+            }
 
             $this->entityManagers[$this->currentBlogId] = $em;
         }


### PR DESCRIPTION
My use case is following, I want to register custom DQL function:

``` yml
dql:
    string_functions:
        field: DoctrineExtensions\Query\Mysql\Field
```

Like documented in http://symfony.com/doc/2.3/cookbook/doctrine/custom_dql_functions.html.

But it is on default entity manager.

I wanted to fix it with:

``` php
$em->getConfiguration()->setCustomStringFunctions($defaultConfig->getCustomStringFunctions());
$em->getConfiguration()->setCustomNumericFunctions($defaultConfig->getCustomNumericFunctions());
$em->getConfiguration()->setCustomDatetimeFunctions($defaultConfig->getCustomDatetimeFunctions());
```

in `Kayue\WordpressBundle\Wordpress\ManagerRegistry`, but there is no `getCustomStringFunctions()` in `Doctrine\ORM\Configuration`.

Do you have any better idea how we can fix this @kayue?
