### PR TITLE
Avoid fatal error when updating other entities.

### DIFF
--- a/Subscriber/TablePrefixSubscriber.php
+++ b/Subscriber/TablePrefixSubscriber.php
@@ -34,6 +34,10 @@ class TablePrefixSubscriber implements EventSubscriber
     {
         $classMetadata = $args->getClassMetadata();
 
+        if (!$classMetadata->getReflectionClass()) {
+            return;
+        }
+
         // Get class annotations
         $classAnnotations = $this->annotatonReader->getClassAnnotations($classMetadata->getReflectionClass());
 


### PR DESCRIPTION
When trying to update some classes in my Symfony project using the command doctrine:generate:entities, I got this error:

`
  [Symfony\Component\Debug\Exception\ContextErrorException]
  Catchable Fatal Error: Argument 1 passed to Doctrine\Common\Annotations\AnnotationReader::getClassAnnotations() must be an instance of ReflectionClass, null given, called in [...]/vendor/kayue/kayue-wordpress-bundle/Kayue/WordpressBundle/Subscriber/TablePrefixSubscriber.php on line 38 and defined
`

I've avoided this error with this code fix.

