### PR TITLE
Remove exception logging in getAttachmentAltText 

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,7 +25,6 @@ services:
         class: Kayue\WordpressBundle\Wordpress\Helper\AttachmentHelper
         arguments:
             - '@kayue_wordpress'
-            - '@logger'
 
     kayue_wordpress.manager.configuration:
         class: '%kayue_wordpress.manager.configuration.class%'

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -25,6 +25,7 @@ services:
         class: Kayue\WordpressBundle\Wordpress\Helper\AttachmentHelper
         arguments:
             - '@kayue_wordpress'
+            - '@logger'
 
     kayue_wordpress.manager.configuration:
         class: '%kayue_wordpress.manager.configuration.class%'

--- a/Twig/Extension/WordpressExtension.php
+++ b/Twig/Extension/WordpressExtension.php
@@ -83,6 +83,7 @@ class WordpressExtension extends \Twig_Extension
             new Twig_SimpleFunction('wp_find_thumbnail', [$this, 'findThumbnail']),
             new Twig_SimpleFunction('wp_find_featured_image', [$this, 'findThumbnail']),
             new Twig_SimpleFunction('wp_get_attachment_url', [$this, 'getAttachmentUrl']),
+            new Twig_SimpleFunction('wp_get_attachment_alt_text', [$this, 'getAttachmentAltText']),
             new Twig_SimpleFunction('wp_get_post_format', [$this, 'getPostFormatByPost']),
 
             // Terms related functions
@@ -177,6 +178,11 @@ class WordpressExtension extends \Twig_Extension
     public function getAttachmentUrl($post, $size = 'post-thumbnail')
     {
         return $this->attachmentHelper->getAttachmentUrl($post, $size);
+    }
+
+    public function getAttachmentAltText($post)
+    {
+        return $this->attachmentHelper->getAttachmentAltText($post);
     }
 
     public function getPostFormatByPost(Post $post)

--- a/Twig/Extension/WordpressExtension.php
+++ b/Twig/Extension/WordpressExtension.php
@@ -174,9 +174,9 @@ class WordpressExtension extends \Twig_Extension
         return $this->attachmentHelper->findThumbnail($post);
     }
 
-    public function getAttachmentUrl($post)
+    public function getAttachmentUrl($post, $size = 'post-thumbnail')
     {
-        return $this->attachmentHelper->getAttachmentUrl($post);
+        return $this->attachmentHelper->getAttachmentUrl($post, $size);
     }
 
     public function getPostFormatByPost(Post $post)

--- a/Wordpress/Helper/AttachmentHelper.php
+++ b/Wordpress/Helper/AttachmentHelper.php
@@ -4,7 +4,6 @@ namespace Kayue\WordpressBundle\Wordpress\Helper;
 
 use Kayue\WordpressBundle\Entity\Post;
 use Kayue\WordpressBundle\Wordpress\ManagerRegistry;
-use Psr\Log\LoggerInterface;
 
 class AttachmentHelper
 {
@@ -14,20 +13,13 @@ class AttachmentHelper
     protected $managerRegistry;
 
     /**
-     * @var LoggerInterface
-     */
-    protected $logger;
-
-    /**
      * AttachmentHelper constructor.
      *
      * @param ManagerRegistry $managerRegistry
-     * @param LoggerInterface $logger
      */
-    public function __construct(ManagerRegistry $managerRegistry, LoggerInterface $logger = null)
+    public function __construct(ManagerRegistry $managerRegistry)
     {
         $this->managerRegistry = $managerRegistry;
-        $this->logger = $logger;
     }
 
     protected function getManager()
@@ -108,11 +100,6 @@ class AttachmentHelper
             ]);
 
         } catch (\Exception $exception) {
-
-            if (null !== $this->logger) {
-
-                $this->logger->error($exception->getMessage());
-            }
 
             return '';
         }

--- a/Wordpress/Helper/AttachmentHelper.php
+++ b/Wordpress/Helper/AttachmentHelper.php
@@ -78,4 +78,30 @@ class AttachmentHelper
 
         return null;
     }
+
+    public function getAttachmentAltText(Post $post)
+    {
+        // Switch to correct blog
+        $originBlogId = $this->getManager()->getBlogId();
+        if ($originBlogId !== $post->getBlogId()) {
+            $this->managerRegistry->setCurrentBlogId($post->getBlogId());
+        }
+
+        $metadata = $this->getManager()->getRepository('KayueWordpressBundle:PostMeta')->findOneBy([
+            'post' => $post,
+            'key' => '_wp_attachment_image_alt',
+        ]);
+
+        // Reset blog ID
+        $this->managerRegistry->setCurrentBlogId($originBlogId);
+
+        if (!$metadata) {
+            return null;
+        }
+
+        $altText = $metadata->getValue();
+
+        return !is_null($altText) ? $altText : '';
+    }
+
 }


### PR DESCRIPTION
Remove the logging part during and exception catch in `getAttachmentAltText` method of `AttachmentHelper`